### PR TITLE
Timeout de conexión implementado en proceso cliente

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ flags = -Wall
 all: client server
 
 client: client.o
-	$(CC) $(flags) -o client client.o
+	$(CC) $(flags) -o client client.o -pthread
 
 client.o: client.cpp util.h
 	$(CC) $(flags) -c client.cpp
 
 server: server.o
-	$(CC) $(flags) -o server server.o
+	$(CC) $(flags) -o server server.o -pthread
 
 server.o: server.cpp util.h
 	$(CC) $(flags) -c server.cpp
@@ -28,4 +28,3 @@ runs: server
 
 run: all
 	./server & ./client
-	

--- a/client.cpp
+++ b/client.cpp
@@ -41,7 +41,7 @@ void * socket_connect(void * flags){
 		fd = client_socket_file_descriptor(f->socket_path);
 		if(fd != -1){
 			f->successful_connection = true;
-			std::cout << "conexión exitosa" << '\n';
+			cout << "conexión exitosa" << endl;
 		}
 		sleep(1);
 	}
@@ -76,7 +76,7 @@ int connection_attempt(char *socket_path){
 	fd = *((int*)(&result));
 	free(flags);
 	if(fd == -1){
-		std::cout << "error: el tiempo máximo para conectar al servidor expiró" << '\n';
+		cout << "error: el tiempo máximo para conectar al servidor expiró" << endl;
 	}
 	return fd;
 }


### PR DESCRIPTION
Actualicé el `makefile` de manera que ahora permita usar `pthread` para ambos procesos (servidor y cliente)

Implementé el `timeout` de 10 segundos para conexión en el proceso cliente, esto quiere decir que si el cliente intenta conectarse al servidor pero se genera error, entonces seguirá intentando conectar hasta que transcurra un tiempo de 10 segundos, una vez transcurrido este tiempo si no consiguió conectarse entonces se muestra un mensaje de error al usuario del proceso cliente. En caso de una conección exitra antes de los 10 segundos entonces se muestra un mensaje al usuario que indica `"conexión exitosa"`


Para conseguir implementar este timeout se creó el siguiente struct:

```
struct ConnectionData {
	bool time_out, successful_connection;
	char * socket_path;
};
```
el cual contiene dos flags para que `connector_thread` y `timer_thread` sepan el estado actual de la conexión y además contiene el socket_path para poder entregarselo a la función que realiza los intentos de conexión (`socket_connect`)

y las siguientes funciones:

`socket_connect`: esta función se le entraga a `connector_thread` y se encarga de realizar 1 intento de conexión por segundo ya que así no sobrepasa el limite máximo de file descriptors que permite el sistema operativo.

`timer`: esta función se le entrega a `timer_thread` y se encarga de contar los 10 segundos mientras que no exista una conexión exitosa, de existir una conexión exitosa o llegar a los 10 segundos entonces detiene la cuenta.

`connection_attempt`: esta función crea `connector_thread` y `timer_thread` de manera paralela entregandoles sus respectivas funciones, luego si la conexión es exitosa retorna el file descriptor del socket y en caso contrario retorna `-1`